### PR TITLE
models for punyo and water jug

### DIFF
--- a/models/jug_5_gallon.sdf
+++ b/models/jug_5_gallon.sdf
@@ -15,7 +15,7 @@
           <izz>0.01394175</izz>
         </inertia>
       </inertial>
-        <visual name="jug_visual">
+      <visual name="jug_visual">
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -23,31 +23,267 @@
           </mesh>
         </geometry>
         <material>
-          <diffuse>0.4 0.4 0.4 1.0</diffuse>
+          <diffuse>0.4 0.4 0.4 0.5</diffuse>
+        </material>
+      </visual>
+
+      <visual name="jug_contact_visual">
+        <pose>0 0 -0.2 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.133</radius>
+            <length>0.06</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
         </material>
       </visual>
       <collision name="jug_collision">
-        <pose>0 0 -0.03 0 0 0</pose>
+        <pose>0 0 -0.2 0 0 0</pose>
         <geometry>
           <cylinder>
-            <radius>0.135</radius>
-            <length>0.40</length>
+            <radius>0.133</radius>
+            <length>0.06</length>
           </cylinder>
         </geometry>
         <surface>
           <friction>
             <ode>
-              <mu>0.5</mu>
-              <mu2>0.5</mu2>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
             </ode>
           </friction>
         </surface>
       </collision>
+
+      <visual name="jug_contact_visual_2">
+        <pose>0 0 -0.115 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.127</radius>
+            <length>0.12</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
+      <collision name="jug_collision_2">
+        <pose>0 0 -0.115 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.127</radius>
+            <length>0.12</length>
+          </cylinder>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+
+      <visual name="jug_contact_visual_3">
+        <pose>0 0 -0.04 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.133</radius>
+            <length>0.04</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
+      <collision name="jug_collision_3">
+        <pose>0 0 -0.04 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.133</radius>
+            <length>0.04</length>
+          </cylinder>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+
+      <visual name="jug_contact_visual_5">
+        <pose>0 0 0.03 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.127</radius>
+            <length>0.1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
+      <collision name="jug_collision_5">
+        <pose>0 0 0.03 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.127</radius>
+            <length>0.1</length>
+          </cylinder>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+
+      <visual name="jug_contact_visual_6">
+        <pose>0 0 0.07 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.133</radius>
+            <length>0.038</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
+      <collision name="jug_collision_6">
+        <pose>0 0 0.07 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.133</radius>
+            <length>0.038</length>
+          </cylinder>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+
+      <visual name="jug_contact_visual_7">
+        <pose>0 0 0.095 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.127</radius>
+            <length>0.05</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
+      <collision name="jug_collision_7">
+        <pose>0 0 0.095 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.127</radius>
+            <length>0.05</length>
+          </cylinder>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+
+      <visual name="jug_contact_visual_8">
+        <pose>0 0 0.115 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.105</radius>
+            <length>0.06</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
+      <collision name="jug_collision_8">
+        <pose>0 0 0.115 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.105</radius>
+            <length>0.06</length>
+          </cylinder>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+
+      <visual name="jug_contact_visual_9">
+        <pose>0 0 0.145 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.06</radius>
+            <length>0.05</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
+      <collision name="jug_collision_9">
+        <pose>0 0 0.145 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.06</radius>
+            <length>0.05</length>
+          </cylinder>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+
+      <visual name="jug_top_contact_visual">
+        <pose>0 0 0.201 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.027</radius>
+            <length>0.065</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
       <collision name="jug_top_collision">
         <pose>0 0 0.201 0 0 0</pose>
         <geometry>
           <cylinder>
-            <radius>0.03</radius>
+            <radius>0.027</radius>
             <length>0.065</length>
           </cylinder>
         </geometry>

--- a/models/jug_5_gallon.sdf
+++ b/models/jug_5_gallon.sdf
@@ -2,7 +2,8 @@
 <sdf version="1.7">
   <model name="jug_5_gallon">
     <!-- This is a model of an empty 5 gallon water jug. -->
-    <!-- The model for a jug of uniform density. -->
+    <!-- The moment of inertia is for a solid cylinder  -->
+    <!-- with uniform density. -->
     <link name="jug">
       <inertial>
         <mass>0.8</mass>

--- a/models/jug_5_gallon_simple.sdf
+++ b/models/jug_5_gallon_simple.sdf
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<sdf version="1.7">
+  <model name="jug_5_gallon">
+    <!-- This is a model of an empty 5 gallon water jug. -->
+    <!-- The model for a jug of uniform density. -->
+    <link name="jug">
+      <inertial>
+        <mass>0.8</mass>
+        <inertia>
+          <ixx>0.00848008333333333</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.012947533333333332</iyy>
+          <iyz>0</iyz>
+          <izz>0.01394175</izz>
+        </inertia>
+      </inertial>
+        <visual name="jug_visual">
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>jug_water_5_gallon.obj</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.4 0.4 1.0</diffuse>
+        </material>
+      </visual>
+
+      <visual name="jug_contact_visual">
+        <pose>0 0 -0.03 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.135</radius>
+            <length>0.40</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
+      <collision name="jug_collision">
+        <pose>0 0 -0.03 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.135</radius>
+            <length>0.40</length>
+          </cylinder>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+
+      <visual name="jug_top_contact_visual">
+        <pose>0 0 0.201 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.027</radius>
+            <length>0.065</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <diffuse>0.4 0.6 0.8 0.9</diffuse>
+        </material>
+      </visual>
+      <collision name="jug_top_collision">
+        <pose>0 0 0.201 0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.027</radius>
+            <length>0.065</length>
+          </cylinder>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/models/jug_5_gallon_simple.sdf
+++ b/models/jug_5_gallon_simple.sdf
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
 <sdf version="1.7">
   <model name="jug_5_gallon">
-    <!-- This is a model of an empty 5 gallon water jug. -->
-    <!-- The model for a jug of uniform density. -->
+      <!-- This is a model of an empty 5 gallon water jug. -->
+    <!-- The moment of inertia is for a solid cylinder  -->
+    <!-- with uniform density. -->
     <link name="jug">
       <inertial>
         <mass>0.8</mass>

--- a/models/q_sys/punyo_water_jug.yml
+++ b/models/q_sys/punyo_water_jug.yml
@@ -1,0 +1,20 @@
+model_directive: package://quasistatic_simulator/punyo.yml
+robots:
+  -
+    name: jaco_left
+    Kp: [800, 600, 600, 600, 400, 200, 200]
+  -
+    name: jaco_right
+    Kp: [800, 600, 600, 600, 400, 200, 200]
+
+objects:
+  -
+    name: jug
+    file: package://quasistatic_simulator/jug_5_gallon.sdf
+
+quasistatic_sim_params:
+  gravity: [0, 0, -9.8]
+  nd_per_contact: 4
+  contact_detection_tolerance: 0.2
+  is_quasi_dynamic: True
+  unactuated_mass_scale: 1

--- a/models/q_sys/punyo_water_jug_no_ground.yml
+++ b/models/q_sys/punyo_water_jug_no_ground.yml
@@ -1,0 +1,20 @@
+model_directive: package://quasistatic_simulator/punyo_no_ground.yml
+robots:
+  -
+    name: jaco_left
+    Kp: [800, 600, 600, 600, 400, 200, 200]
+  -
+    name: jaco_right
+    Kp: [800, 600, 600, 600, 400, 200, 200]
+
+objects:
+  -
+    name: jug
+    file: package://quasistatic_simulator/jug_5_gallon.sdf
+
+quasistatic_sim_params:
+  gravity: [0, 0, 0]
+  nd_per_contact: 4
+  contact_detection_tolerance: 0.2
+  is_quasi_dynamic: True
+  unactuated_mass_scale: 5


### PR DESCRIPTION
- Includes models for the water jug with 8 collision geometries to closely model the object and another simpler version with only 2. 
- Includes the yml directives for punyo and water jug